### PR TITLE
Remove eigen-git-mirror dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "deps/eigen-git-mirror"]
-	path = deps/eigen-git-mirror
-	url = https://github.com/eigenteam/eigen-git-mirror.git
 [submodule "deps/enoki"]
 	path = deps/enoki
 	url = https://github.com/mitsuba-renderer/enoki.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(fcpw)
 
+find_package( Eigen3 REQUIRED )
+
 option(FCPW_USE_ENOKI "Build enoki" ON)
 option(FCPW_USE_EIGHT_WIDE_BRANCHING "Use 8 wide branching (default 4)" OFF)
 option(FCPW_BUILD_TESTS "Build tests" OFF)
@@ -23,9 +25,9 @@ endif()
 get_directory_property(hasParent PARENT_DIRECTORY)
 
 if(hasParent)
-    set(FCPW_EIGEN_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/deps/eigen-git-mirror PARENT_SCOPE)
+	set(FCPW_EIGEN_INCLUDES ${EIGEN3_INCLUDE_DIRS} PARENT_SCOPE)
 else()
-    set(FCPW_EIGEN_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/deps/eigen-git-mirror)
+	set(FCPW_EIGEN_INCLUDES ${EIGEN3_INCLUDE_DIRS})
 endif()
 
 if(FCPW_BUILD_TESTS)


### PR DESCRIPTION
For your consideration: this mirror is apparently deprecated and slotted for deletion (though I have no idea when or even if that will happen)

Have found it easier to just build off any system-wide available eigen package, and proposing PR as such