### PR TITLE
Prioritize searching for slang libraries from deps/slang/lib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,13 +57,13 @@ if(FCPW_ENABLE_GPU_SUPPORT)
 
     # find the .lib/.so files
     set(SLANG_LIBRARY_PATH ${CMAKE_CURRENT_SOURCE_DIR}/deps/slang/lib)
-    find_library(FCPW_SLANG_LIBRARY NAMES slang HINTS ${SLANG_LIBRARY_PATH} NO_CMAKE_FIND_ROOT_PATH)
+    find_library(FCPW_SLANG_LIBRARY NAMES slang HINTS ${SLANG_LIBRARY_PATH})
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        find_library(FCPW_SLANG_GLSLANG_LIBRARY NAMES slang-glslang HINTS ${SLANG_LIBRARY_PATH} NO_CMAKE_FIND_ROOT_PATH)
+        find_library(FCPW_SLANG_GLSLANG_LIBRARY NAMES slang-glslang HINTS ${SLANG_LIBRARY_PATH})
     else()
         set(FCPW_SLANG_GLSLANG_LIBRARY "")
     endif()
-    find_library(FCPW_GFX_LIBRARY NAMES gfx HINTS ${SLANG_LIBRARY_PATH} NO_CMAKE_FIND_ROOT_PATH)
+    find_library(FCPW_GFX_LIBRARY NAMES gfx HINTS ${SLANG_LIBRARY_PATH})
 
     # find the corresponding .dll files
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,13 +57,13 @@ if(FCPW_ENABLE_GPU_SUPPORT)
 
     # find the .lib/.so files
     set(SLANG_LIBRARY_PATH ${CMAKE_CURRENT_SOURCE_DIR}/deps/slang/lib)
-    find_library(FCPW_SLANG_LIBRARY NAMES slang PATHS ${SLANG_LIBRARY_PATH})
+    find_library(FCPW_SLANG_LIBRARY NAMES slang HINTS ${SLANG_LIBRARY_PATH} NO_CMAKE_FIND_ROOT_PATH)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        find_library(FCPW_SLANG_GLSLANG_LIBRARY NAMES slang-glslang PATHS ${SLANG_LIBRARY_PATH})
+        find_library(FCPW_SLANG_GLSLANG_LIBRARY NAMES slang-glslang HINTS ${SLANG_LIBRARY_PATH} NO_CMAKE_FIND_ROOT_PATH)
     else()
         set(FCPW_SLANG_GLSLANG_LIBRARY "")
     endif()
-    find_library(FCPW_GFX_LIBRARY NAMES gfx PATHS ${SLANG_LIBRARY_PATH})
+    find_library(FCPW_GFX_LIBRARY NAMES gfx HINTS ${SLANG_LIBRARY_PATH} NO_CMAKE_FIND_ROOT_PATH)
 
     # find the corresponding .dll files
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")


### PR DESCRIPTION
`README.md` states:
> Finally, for GPU support the `FCPW_ENABLE_GPU_SUPPORT` option **assumes Slang binaries are available under `deps/slang`**

However, the behavior of `find_library` in the existing `CMakeLists.txt` is to **search the default path first** and then fallback to the path specified by `PATHS`, which is inconsistent with the expectations given in `README.md`.

When the operating system has installed slang through AUR or other methods, this configuration may cause link errors:

```
[build] /usr/bin/ld: CMakeFiles/poc.dir/test.cu.o: undefined reference to symbol 'spReflectionTypeLayout_GetElementTypeLayout'
[build] /usr/bin/ld: /home/user/poc/ext/fcpw/deps/slang/lib/libslang.so: error adding symbols: DSO missing from command line
[build] clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

This PR fixes the problem.

See the CMake mailing list for a detailed explanation: https://cmake.org/pipermail/cmake/2010-October/040460.html .